### PR TITLE
Support user-defined CustomResource providers to register with go-cloudformation

### DIFF
--- a/custom_resource_test.go
+++ b/custom_resource_test.go
@@ -1,0 +1,54 @@
+package cloudformation
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+type MyResource struct {
+	CloudFormationCustomResource
+	Foo *StringExpr
+}
+
+func customTypeProvider(resourceType string) ResourceProperties {
+	switch resourceType {
+	case "Custom::MyResource":
+		return &MyResource{}
+	}
+	return nil
+}
+
+func init() {
+	RegisterCustomResourceProvider(customTypeProvider)
+}
+
+func TestCustomResource(t *testing.T) {
+	myResourceInstance, ok := NewResourceByType("Custom::MyResource").(*MyResource)
+	if !ok {
+		t.Fatalf("Failed to call user provided CustomResourceProvider")
+	}
+	myResourceInstance.ServiceToken = String("arn:aws:sns:us-east-1:84969EXAMPLE:CRTest")
+	myResourceInstance.Foo = String("Hello World")
+
+	templ := NewTemplate()
+	templ.Description = "Test Custom Resource"
+	templ.AddResource("MyCustomResource", myResourceInstance)
+
+	// Verify marshaled results
+	output, err := json.Marshal(templ)
+	if err != nil {
+		t.Fatalf("marshal: %s", err)
+	}
+	parsedOutput := map[string]interface{}{}
+	json.Unmarshal(output, &parsedOutput)
+
+	resources := parsedOutput["Resources"].(map[string]interface{})
+	customResource := resources["MyCustomResource"].(map[string]interface{})
+	properties := customResource["Properties"].(map[string]interface{})
+	if "" == properties["ServiceToken"].(string) {
+		t.Fatalf("Properties.ServiceToken is empty")
+	}
+	if "" == properties["Foo"].(string) {
+		t.Fatalf("Properties.Foo is empty")
+	}
+}

--- a/schema.go
+++ b/schema.go
@@ -3,6 +3,14 @@ package cloudformation
 import "time"
 import "encoding/json"
 
+type CustomResourceProvider func(customResourceType string) ResourceProperties
+
+var customResourceProviders []CustomResourceProvider
+
+func RegisterCustomResourceProvider(provider CustomResourceProvider) {
+	customResourceProviders = append(customResourceProviders, provider)
+}
+
 // AutoScalingAutoScalingGroup represents AWS::AutoScaling::AutoScalingGroup
 //
 // see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html
@@ -10316,6 +10324,14 @@ func NewResourceByType(typeName string) ResourceProperties {
 		return &SSMDocument{}
 	case "AWS::WorkSpaces::Workspace":
 		return &WorkSpacesWorkspace{}
+
+	default:
+		for _, eachProvider := range customResourceProviders {
+			customType := eachProvider(typeName)
+			if nil != customType {
+				return customType
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
If the `NewResourceByType` _resourceType_ is not found, the list of custom resource providers is queried for a potential custom provider.  See `custom_resource_test.go` for usage.

https://github.com/crewjam/go-cloudformation/issues/2