### PR TITLE
Update Integer param type, slice types, add `DeletionPolicy` attribute

### DIFF
--- a/examples/app.go
+++ b/examples/app.go
@@ -12,7 +12,7 @@ import (
 func makeTemplate() *cf.Template {
 	t := cf.NewTemplate()
 	t.Description = "example production infrastructure"
-	t.Parameters["DnsName"] = cf.Parameter{
+	t.Parameters["DnsName"] = &cf.Parameter{
 		Description: "The top level DNS name for the infrastructure",
 		Type:        "String",
 		Default:     "preview.example.io",

--- a/examples/app_old.go
+++ b/examples/app_old.go
@@ -9,7 +9,7 @@ import cf "github.com/crewjam/go-cloudformation"
 func makeTemplateTheOldWay() *cf.Template {
 	t := cf.NewTemplate()
 	t.Description = "example production infrastructure"
-	t.Parameters["DnsName"] = cf.Parameter{
+	t.Parameters["DnsName"] = &cf.Parameter{
 		Description: "The top level DNS name for the infrastructure",
 		Type:        "String",
 		Default:     "preview.example.io",

--- a/integer.go
+++ b/integer.go
@@ -70,16 +70,6 @@ func (x *IntegerExpr) UnmarshalJSON(data []byte) error {
 }
 
 // Integer returns a new IntegerExpr representing the literal value v.
-func Integer(v int) *IntegerExpr {
-	return &IntegerExpr{Literal: int64(v)}
-}
-
-// Integer32 returns a new IntegerExpr representing the literal value v.
-func Integer32(v int32) *IntegerExpr {
-	return &IntegerExpr{Literal: int64(v)}
-}
-
-// Integer64 returns a new IntegerExpr representing the literal value v.
-func Integer64(v int64) *IntegerExpr {
+func Integer(v int64) *IntegerExpr {
 	return &IntegerExpr{Literal: v}
 }

--- a/integer.go
+++ b/integer.go
@@ -18,7 +18,7 @@ import (
 //
 type IntegerExpr struct {
 	Func    IntegerFunc
-	Literal int
+	Literal int64
 }
 
 // MarshalJSON returns a JSON representation of the object
@@ -31,7 +31,7 @@ func (x IntegerExpr) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON sets the object from the provided JSON representation
 func (x *IntegerExpr) UnmarshalJSON(data []byte) error {
-	var v int
+	var v int64
 	err := json.Unmarshal(data, &v)
 	if err == nil {
 		x.Func = nil
@@ -44,7 +44,7 @@ func (x *IntegerExpr) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &strValue); err == nil {
 		if v, err := strconv.ParseInt(strValue, 10, 64); err == nil {
 			x.Func = nil
-			x.Literal = int(v)
+			x.Literal = v
 			return nil
 		}
 	}
@@ -71,5 +71,15 @@ func (x *IntegerExpr) UnmarshalJSON(data []byte) error {
 
 // Integer returns a new IntegerExpr representing the literal value v.
 func Integer(v int) *IntegerExpr {
+	return &IntegerExpr{Literal: int64(v)}
+}
+
+// Integer32 returns a new IntegerExpr representing the literal value v.
+func Integer32(v int32) *IntegerExpr {
+	return &IntegerExpr{Literal: int64(v)}
+}
+
+// Integer64 returns a new IntegerExpr representing the literal value v.
+func Integer64(v int64) *IntegerExpr {
 	return &IntegerExpr{Literal: v}
 }

--- a/integer_test.go
+++ b/integer_test.go
@@ -37,7 +37,7 @@ func (testSuite *IntegerTest) TestInteger(c *C) {
 
 	inputBuf = `{"A": "invalid"}`
 	err = json.Unmarshal([]byte(inputBuf), &v)
-	c.Assert(err, ErrorMatches, "json: cannot unmarshal string into Go value of type int")
+	c.Assert(err, ErrorMatches, "json: cannot unmarshal string into Go value of type int64")
 
 	inputBuf = `{"A": {"Fn::Missing": "invalid"}}`
 	err = json.Unmarshal([]byte(inputBuf), &v)

--- a/template.go
+++ b/template.go
@@ -123,7 +123,7 @@ func (r *Resource) UnmarshalJSON(buf []byte) error {
 	typeName := m["Type"].(string)
 	r.DependsOn, _ = m["DependsOn"].([]string)
 	r.Metadata, _ = m["Metadata"].(map[string]interface{})
-	r.DeletionPolicy = m["DeletionPolicy"].(string)
+	r.DeletionPolicy, _ = m["DeletionPolicy"].(string)
 	r.Properties = NewResourceByType(typeName)
 	if r.Properties == nil {
 		return fmt.Errorf("unknown resource type: %s", typeName)


### PR DESCRIPTION
Checking a few of the service APIs, it looks like the AWS SDK (http://docs.aws.amazon.com/sdk-for-go/api/) appears to use `*int64`.