### PR TITLE
IAM policy: Add support for the "*" value for Principal

### DIFF
--- a/iam_policy.go
+++ b/iam_policy.go
@@ -1,5 +1,7 @@
 package cloudformation
 
+import "encoding/json"
+
 // IAMPolicyDocument represents an IAM policy document
 type IAMPolicyDocument struct {
 	Version   string `json:",omitempty"`
@@ -8,8 +10,10 @@ type IAMPolicyDocument struct {
 
 // IAMPrincipal represents a principal in an IAM policy
 type IAMPrincipal struct {
-	Service *StringListExpr `json:",omitempty"`
-	AWS     *StringListExpr `json:",omitempty"`
+	AWS           *StringListExpr `json:",omitempty"`
+	CanonicalUser *StringListExpr `json:",omitempty"`
+	Federated     *StringListExpr `json:",omitempty"`
+	Service       *StringListExpr `json:",omitempty"`
 }
 
 // IAMPolicyStatement represents an IAM policy statement
@@ -22,4 +26,49 @@ type IAMPolicyStatement struct {
 	NotAction    *StringListExpr `json:",omitempty"`
 	Resource     *StringListExpr `json:",omitempty"`
 	Condition    interface{}     `json:",omitempty"`
+}
+
+// Avoid infinite loops when we just want to marshal the struct normally
+type iamPrincipalCopy IAMPrincipal
+
+// MarshalJSON returns a JSON representation of the object. This has been added
+// to handle the special case of "*" as the Principal value.
+func (i IAMPrincipal) MarshalJSON() ([]byte, error) {
+	// Special case for "*"
+	if i.AWS != nil && len(i.AWS.Literal) == 1 && i.AWS.Literal[0].Literal == "*" {
+		return json.Marshal(i.AWS.Literal[0].Literal)
+	}
+
+	c := iamPrincipalCopy(i)
+
+	return json.Marshal(c)
+}
+
+// UnmarshalJSON sets the object from the provided JSON representation. This has
+// been added to handle the special case of "*" as the Principal value.
+func (i *IAMPrincipal) UnmarshalJSON(data []byte) error {
+	// Handle single string values like "*"
+	var v string
+	err := json.Unmarshal(data, &v)
+	if err == nil {
+		i.AWS = StringList(String(v))
+		i.CanonicalUser = nil
+		i.Federated = nil
+		i.Service = nil
+		return nil
+	}
+
+	// Handle all other values
+	var v2 iamPrincipalCopy
+	err = json.Unmarshal(data, &v2)
+	if err != nil {
+		return err
+	}
+
+	i.AWS = v2.AWS
+	i.CanonicalUser = v2.CanonicalUser
+	i.Federated = v2.Federated
+	i.Service = v2.Service
+
+	return nil
 }

--- a/iam_policy_test.go
+++ b/iam_policy_test.go
@@ -1,0 +1,104 @@
+package cloudformation
+
+import (
+	"encoding/json"
+
+	. "gopkg.in/check.v1"
+)
+
+type IAMPolicyTest struct{}
+
+var _ = Suite(&IAMPolicyTest{})
+
+func (testSuite *IAMPolicyTest) TestIAMPolicyStatement(c *C) {
+	// We are primarily testing the parsing of Principal
+	p := `{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Sid":"AddPerm",
+      "Effect":"Allow",
+      "Principal": "*",
+      "Action":["s3:GetObject"],
+      "Resource":["arn:aws:s3:::examplebucket/*"]
+    }
+  ]
+}`
+
+	v := IAMPolicyDocument{}
+	err := json.Unmarshal([]byte(p), &v)
+	c.Assert(err, IsNil)
+	c.Assert(v.Version, Equals, "2012-10-17")
+	c.Assert(v.Statement, HasLen, 1)
+	s := v.Statement[0]
+	c.Assert(s.Sid, Equals, "AddPerm")
+	c.Assert(s.Effect, Equals, "Allow")
+	c.Assert(s.Principal.AWS, DeepEquals, StringList(String("*")))
+	c.Assert(s.Principal.CanonicalUser, IsNil)
+	c.Assert(s.Principal.Federated, IsNil)
+	c.Assert(s.Principal.Service, IsNil)
+	c.Assert(s.Action, DeepEquals, StringList(String("s3:GetObject")))
+	c.Assert(s.Resource, DeepEquals, StringList(String("arn:aws:s3:::examplebucket/*")))
+
+	// Make sure we marshall the "*" back properly
+	b, err := json.Marshal(v)
+	c.Assert(err, IsNil)
+	c.Assert(string(b), Equals, `{"Version":"2012-10-17","Statement":[{"Sid":"AddPerm","Effect":"Allow","Principal":"*","Action":["s3:GetObject"],"Resource":["arn:aws:s3:::examplebucket/*"]}]}`)
+
+	// Try other variations of Principal
+	p = `{
+   "Version":"2012-10-17",
+   "Id":"PolicyForCloudFrontPrivateContent",
+   "Statement":[
+     {
+       "Sid":" Grant a CloudFront Origin Identity access to support private content",
+       "Effect":"Allow",
+       "Principal":{"CanonicalUser":"79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"},
+       "Action":"s3:GetObject",
+       "Resource":"arn:aws:s3:::example-bucket/*"
+     }
+   ]
+}`
+
+	err = json.Unmarshal([]byte(p), &v)
+	c.Assert(err, IsNil)
+	c.Assert(s.Principal.AWS, IsNil)
+	c.Assert(s.Principal.CanonicalUser, DeepEquals, StringList(String("79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be")))
+	c.Assert(s.Principal.Federated, IsNil)
+	c.Assert(s.Principal.Service, IsNil)
+
+	// Try marshalling this too
+	b, err = json.Marshal(v)
+	c.Assert(err, IsNil)
+	c.Assert(string(b), Equals, `{"Version":"2012-10-17","Statement":[{"Sid":" Grant a CloudFront Origin Identity access to support private content","Effect":"Allow","Principal":{"CanonicalUser":["79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"]},"Action":["s3:GetObject"],"Resource":["arn:aws:s3:::example-bucket/*"]}]}`)
+
+	p = `{
+   "Version":"2012-10-17",
+   "Id":"PolicyForCloudFrontPrivateContent",
+   "Statement":[
+     {
+       "Sid":" Grant a CloudFront Origin Identity access to support private content",
+       "Effect":"Allow",
+       "Principal": {
+         "Service": [
+           "ec2.amazonaws.com",
+           "datapipeline.amazonaws.com"
+         ]
+       },
+       "Action":"s3:GetObject",
+       "Resource":"arn:aws:s3:::example-bucket/*"
+     }
+   ]
+}`
+
+	err = json.Unmarshal([]byte(p), &v)
+	c.Assert(err, IsNil)
+	c.Assert(s.Principal.AWS, IsNil)
+	c.Assert(s.Principal.CanonicalUser, IsNil)
+	c.Assert(s.Principal.Federated, IsNil)
+	c.Assert(s.Principal.Service, DeepEquals, StringList(String("ec2.amazonaws.com"), String("datapipeline.amazonaws.com")))
+
+	b, err = json.Marshal(v)
+	c.Assert(err, IsNil)
+	c.Assert(string(b), Equals, `{"Version":"2012-10-17","Statement":[{"Sid":" Grant a CloudFront Origin Identity access to support private content","Effect":"Allow","Principal":{"Service":["ec2.amazonaws.com","datapipeline.amazonaws.com"]},"Action":["s3:GetObject"],"Resource":["arn:aws:s3:::example-bucket/*"]}]}`)
+}


### PR DESCRIPTION
This also add supports for CanonicalUser and Federated which are other
possible options for Principal. See:

http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#Principal